### PR TITLE
listen on 'secureConnection' for https servers

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,17 @@ function addShutdown(server) {
     }
   };
 
+  function onConnection(socket) {
+    var id = connectionCounter++;
+    socket._isIdle = true;
+    socket._connectionId = id;
+    connections[id] = socket;
+
+    socket.on('close', function() {
+      delete connections[id];
+    });
+  };
+
   server.on('request', function(req, res) {
     req.socket._isIdle = false;
 
@@ -32,16 +43,8 @@ function addShutdown(server) {
     });
   });
 
-  server.on('connection', function(socket) {
-    var id = connectionCounter++;
-    socket._isIdle = true;
-    socket._connectionId = id;
-    connections[id] = socket;
-
-    socket.on('close', function() {
-      delete connections[id];
-    });
-  });
+  server.on('connection', onConnection);
+  server.on('secureConnection', onConnection);
 
   function shutdown(force, cb) {
     isShuttingDown = true;


### PR DESCRIPTION
Per the [Node docs](https://nodejs.org/api/https.html#https_class_https_server), `https.Server` is a subclass of `tls.Server`, which emits a [`secureConnection` event](https://nodejs.org/api/tls.html#tls_event_secureconnection). This PR adds the same handling logic for that even as currently exists for `connection`