### PR TITLE
Corrected TypeScript type definitions so that both HTTP and HTTPS servers are supported

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 // Missing type definitions
 
-import { Server } from 'http';
+import { Server } from 'net';
 
 export = wrapShutdown;
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "repository": "thedillonb/http-shutdown",
   "license": "MIT",
   "devDependencies": {
+    "@types/node": "^12.12.6",
     "chai": "^3.4.1",
     "istanbul": "^0.4.1",
     "mocha": "^2.3.4",


### PR DESCRIPTION
Hey @thedillonb and thanks for your work on `http-shutdown`!

I use it as part of the [Serenity/JS project](https://serenity-js.org) to allow people to [manage local test servers](https://github.com/jan-molak/serenity-js/tree/2.0/packages/local-server).

I noticed that the change introduced in version 1.2.1 breaks backwards compatibility and prevents TypeScript code from passing a HTTPs server to `http-shutdown`.

In order to address that issue, the type of the `Server` object needs to be changed from `http.Server` to `net.Server`.

That's because in the inheritance chain, the `net.Server` type is the first common element:
- HTTPs server: `https.Server -> tls.Server -> net.Server -> events.EventEmitter`
- HTTP server: `http.Server -> net.Server -> events.EventEmitter`

Please let me know if your happy with this PR or if you'd like me to provide any additional details!

I've [tested `http-shutdown` to death](https://github.com/jan-molak/serenity-js/blob/2.0/packages/local-server/spec/servers.spec.ts) in the context of Serenity/JS, so am fairly confident that the only issue that needs addressing is the type definitions :-)

All the best,
Jan